### PR TITLE
Names with spaces can now be tracked

### DIFF
--- a/whatsappbeacon.py
+++ b/whatsappbeacon.py
@@ -9,6 +9,7 @@ from selenium.common.exceptions import InvalidArgumentException
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.chrome.options import Options
 from utils.database import Database
+from time import sleep
 import os
 import time
 import math
@@ -196,12 +197,15 @@ def main():
 	parser.add_argument('-u', '--username', help='Username to track', required=True)
 	parser.add_argument('-l', '--language', help='Language to use', required=True, choices=['en', 'es', 'fr', 'pt', 'de', 'cat','tr'])
 	parser.add_argument('-e','--excel',help="Db to Excel Converter",required=False,action='store_true')
+	parser.add_argument('-s', '--split', help="change the prefix with which the spaces of the --username flag will be separated", required=False, default="-")
 
 	args = parser.parse_args()
 
+	user_name = " ".join(args.username.split(args.split))
 
 	driver = whatsapp_login()
-	study_user(driver, args.username, args.language,args.excel)
+	
+	study_user(driver, user_name, args.language,args.excel)
 
 
 


### PR DESCRIPTION
### **Names with spaces**
The functionality consists in that usernames that contain spaces can also be traced using the "-" separator.

However, if the user wishes, he can choose his own flag for the separator using the "--split" argument, by default if an argument is not given it must be separated with "-" for example "user-name"

_**Without Flag --split**_
`
python3 whatsappbeacon.py --username Jon-Doe --language en
`

_**With Flag --split**_
`
python3 whatsappbeacon.py --username Jon.Doe --language en --split .
`

_**RESULT NAME**_
`
username: Jon Doe
`

**Important**
I managed to test the compatibility of this and everything went correctly, also some ascii characters can be included without major inconveniences