### PR TITLE
Automatically detects when chats load

### DIFF
--- a/whatsappbeacon.py
+++ b/whatsappbeacon.py
@@ -145,6 +145,32 @@ def study_user(driver, user, language, excel):
 			print('ERROR: Your WhatsApp window has been minimized or closed, try running the code again, shutting down...')
 			exit()
 
+def whatsapp_load(driver) -> None:
+		"""
+		The find_element method is used by means of which we are going to search for XPath "wa-web-loading-screen"
+		which is an html element which is present exclusively when the web.whatsapp.com is loading
+
+		Args:
+		- Driver of the web browser
+
+		Returns:
+		None
+
+		"""
+		while True:
+			try:
+				loading = driver.find_element(by=By.XPATH, value='//div[@data-testid="wa-web-loading-screen"]')
+				loading.click()
+				print("\n Loaded")
+				break
+			except Exception:
+				print("Loading...", end=f"\r")
+
+		while True:
+			try:
+				loading.click()
+			except Exception:
+				break
 
 
 def whatsapp_login():
@@ -164,8 +190,10 @@ def whatsapp_login():
 		options.add_experimental_option('excludeSwitches', ['enable-logging'])
 		driver = webdriver.Chrome(options=options)
 		driver.get('https://web.whatsapp.com')
-		assert 'WhatsApp' in driver.title 
-		input('Press any key when you are at the chat menu...')
+		assert 'WhatsApp' in driver.title
+
+		# Detects when you can search for the user that was introduced (the page was fully loaded)
+		whatsapp_load(driver=driver)
 
 		return driver
 


### PR DESCRIPTION
# **Feautures**
These new features seek to improve the user experience in various aspects compared to the automation of this task, since now it is sought that the program automatically detects when it is inside the chat tray on the web.whatsapp.com page avoiding that the user must tell the program when it has finished loading the page.


## **How does it work?**
The operation for the detection of the WhatsApp page is quite simple
- Initially, a component is removed that is only on the WhatsApp loading page
- Then it is checked if the element is still there and while the element is still there, the user will not be tracked or the function in charge of doing so will be called
- When it is detected that the element no longer exists, the normal flow of the whatsapp_loggin() function continues as normal


https://github.com/jasperan/whatsapp-osint/assets/111100025/08abb1f5-312b-4c38-b726-1d9913b17f11

